### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,21 @@ You can use AppCorner on appcorner.it to share your apps with others developers,
 
 **To see your app on appcorner.it (website/twitter/facebook) and iTunesPicker as price reduction, post your app on appcorner social with the red clock icon enabled at least 12 hours before change the price from the App Store.**  
 
-###Show apps on your web site for free and make money with iTunes Affiliate Program
+### Show apps on your web site for free and make money with iTunes Affiliate Program
 **You can create a website with price drops as [appcorner.it](http://www.appcorner.it/en/) in minutes**, refer to [README](https://github.com/appcornerit/AppCorner-Social/tree/master/appcorner.it).
  Price drops are also available on your iPhone, take a look at the [iTunesPicker](https://github.com/appcornerit/iTunesPicker) project.
 
 You can also use AppCorner for iPhone to show your posted apps (in any country and language available in App Store) with your comments on your website using appcorner.it as service for free (without install deployd on your server), refer to [README](https://github.com/appcornerit/AppCorner-Social/tree/master/appcorner.it)
 
-###AppCorner on your server
+### AppCorner on your server
 **Build your server is quite simple**, refer to [README](https://github.com/appcornerit/AppCorner-Social/tree/master/Deployd-Modules) to try the app with your server (on localhost or aws or with loopback as backend instead of deployd).
 
 This project uses APN, WebSockets and containts an updated version of [DeploydKit](https://github.com/appcornerit/AppCorner-Social/tree/master/External/DeploydKit) project.
 
-###Publish on App Store
+### Publish on App Store
 You can build your social app to publish on App Store that share musics, books or TV series (from iTunes) quickly with few changes in DAAppsViewController.m, PAAppStoreQuery.m.
 
-###The story
+### The story
 - I developed [DeploydKit](https://github.com/appcornerit/DeploydKit)
 - I saw [Anypic](https://github.com/ParsePlatform/Anypic) a full featured photo sharing app built by [Parse.com](https://parse.com)
 - I developed a layer called [ParseKit] (https://github.com/appcornerit/AppCorner-Social/tree/master/External/ParseKit) to replace Parse framework (it wasn't open source at the time) on top of DeploydKit

--- a/appcorner.it/README.md
+++ b/appcorner.it/README.md
@@ -1,6 +1,6 @@
 Show apps on your web site and make money with iTunes Affiliate Program
 ============
-###You can create a website with price drops as appcorner.it in minutes an make money with your iTunes affiliate token
+### You can create a website with price drops as appcorner.it in minutes an make money with your iTunes affiliate token
 Log in on AppCorner for iPhone (don't use the simulator), retrive your facebook id (you could add a breakpoint in PFLogInViewController.m for facebookId variable).
 
 Paste your facebook id in `appcorner.js`, open pricedrops.html (responsive web design), that's it!
@@ -11,16 +11,16 @@ See how to join to [iTunes Affiliate Program](https://www.apple.com/itunes/affil
 
 Cannot find enough discounts for your country? Open an issue and I will add your country to monitoring prices on appcorner.it
 
-###You can use AppCorner for iPhone to show your posted apps with your comments on your website an make money with your iTunes affiliate token
+### You can use AppCorner for iPhone to show your posted apps with your comments on your website an make money with your iTunes affiliate token
 
 Post at least one app in AppCorner for iPhone  (don't use the simulator), retrive your facebook id (you could add a breakpoint in PFLogInViewController.m for facebookId variable).
 
 Paste your facebook id in `appcorner.js`, open userapps.html (responsive web design), that's it!
 
-##Contribute to open source
+## Contribute to open source
 I encourage anyone who wants to build your own widgets to show the apps as open source, who know php could create a plugin for wordpress.
 
-##Terms of service
+## Terms of service
 This free service on appcorner.it is **WITHOUT WARRANTY OF ANY KIND AND UPTIME AVAILABILITY**, one facebook id can be used for a single domain only and you must leave the logo of appcorner.it (with the link to appcorner.it) on your webpage that use the service, please do not abuse, otherwise the service will turned off.
 
 The service requires to compile and login in AppCorner for iPhone, recovery the facebook id to copy in appcorner.js, in the future everything will be easier, for now it remains a service for developers only.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
